### PR TITLE
Modify auto-merge condition in UpdateData.yaml

### DIFF
--- a/.github/workflows/UpdateData.yaml
+++ b/.github/workflows/UpdateData.yaml
@@ -60,7 +60,6 @@ jobs:
           add-paths: R/sysdata.rda
 
       - name: Auto-merge PR
-        if: github.actor == 'github-actions[bot]'
         uses: peter-evans/merge-pull-request@v3
         with:
           pull-request: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
Remove condition for auto-merging PRs by GitHub Actions bot.